### PR TITLE
Community original

### DIFF
--- a/src/PowerTools/DbContextPackage.cs
+++ b/src/PowerTools/DbContextPackage.cs
@@ -16,14 +16,14 @@ namespace Microsoft.DbContextPackage
     using System.Xml.Linq;
     using EnvDTE;
     using EnvDTE80;
-    using Microsoft.DbContextPackage.Extensions;
-    using Microsoft.DbContextPackage.Handlers;
-    using Microsoft.DbContextPackage.Resources;
-    using Microsoft.DbContextPackage.Utilities;
-    using Microsoft.VisualStudio;
-    using Microsoft.VisualStudio.Shell;
-    using Microsoft.VisualStudio.Shell.Design;
-    using Microsoft.VisualStudio.Shell.Interop;
+    using Extensions;
+    using Handlers;
+    using Resources;
+    using Utilities;
+    using VisualStudio;
+    using VisualStudio.Shell;
+    using VisualStudio.Shell.Design;
+    using VisualStudio.Shell.Interop;
     using Configuration = Configuration;
     using ConfigurationManager = ConfigurationManager;
 
@@ -616,8 +616,8 @@ namespace Microsoft.DbContextPackage
         {
             if (attr != null)
             {
-                string tempFileName = null;
-                string tempQualifiedFileName = null;
+                string tempFileName;
+                string tempQualifiedFileName;
                 do
                 {
                     tempFileName = Path.GetRandomFileName();

--- a/src/PowerTools/Dialogs/AboutDialog.xaml
+++ b/src/PowerTools/Dialogs/AboutDialog.xaml
@@ -1,4 +1,4 @@
-﻿<dw:DialogWindow x:Class="Microsoft.DbContextPackage.AboutDialog"
+﻿<dw:DialogWindow x:Class="Microsoft.DbContextPackage.Dialogs.AboutDialog"
              xmlns:dw="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.14.0"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -22,7 +22,7 @@
                 <Hyperlink TextDecorations="" Click="GalleryLink_Click" x:Name="GalleryLink">
             <Run Text="Visual Studio Marketplace"/></Hyperlink></Bold>
         </TextBlock>
-        <dw:DialogButton IsCancel="True" IsDefault="True" Name="OKButton" Click="OKButton_Click" Grid.Row="1" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,12,11.5" Height="24" Width="75">OK</dw:DialogButton>
+        <dw:DialogButton IsCancel="True" IsDefault="True" Name="OKButton" Click="OKButton_Click" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,12,11.5" Height="24" Width="75">OK</dw:DialogButton>
     </StackPanel>
     <!--<Grid ClipToBounds="False" Margin="0,0,0,38">
         <Grid.RowDefinitions>

--- a/src/PowerTools/Dialogs/AboutDialog.xaml.cs
+++ b/src/PowerTools/Dialogs/AboutDialog.xaml.cs
@@ -1,8 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Windows;
-using System;
 
-namespace Microsoft.DbContextPackage
+namespace Microsoft.DbContextPackage.Dialogs
 {
     public partial class AboutDialog
     {

--- a/src/PowerTools/Extensions/EdmSchemaErrorException.cs
+++ b/src/PowerTools/Extensions/EdmSchemaErrorException.cs
@@ -5,13 +5,11 @@ namespace Microsoft.DbContextPackage.Extensions
     using System.Collections.Generic;
     using System.Data.Metadata.Edm;
     using System.Runtime.Serialization;
-    using Microsoft.DbContextPackage.Utilities;
+    using Utilities;
 
     [Serializable]
     public class EdmSchemaErrorException : Exception
     {
-        private readonly IEnumerable<EdmSchemaError> _errors;
-
         public EdmSchemaErrorException()
         {
         }
@@ -26,7 +24,7 @@ namespace Microsoft.DbContextPackage.Extensions
         {
             Check.NotNull(errors, "errors");
 
-            _errors = errors;
+            Errors = errors;
         }
 
         public EdmSchemaErrorException(string message, Exception innerException)
@@ -39,19 +37,16 @@ namespace Microsoft.DbContextPackage.Extensions
         {
             Check.NotNull(info, "info");
 
-            _errors = (IEnumerable<EdmSchemaError>)info.GetValue("Errors", typeof(IEnumerable<EdmSchemaError>));
+            Errors = (IEnumerable<EdmSchemaError>)info.GetValue("Errors", typeof(IEnumerable<EdmSchemaError>));
         }
 
-        public IEnumerable<EdmSchemaError> Errors
-        {
-            get { return _errors; }
-        }
+        public IEnumerable<EdmSchemaError> Errors { get; }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             Check.NotNull(info, "info");
 
-            info.AddValue("Errors", _errors);
+            info.AddValue("Errors", Errors);
 
             base.GetObjectData(info, context);
         }

--- a/src/PowerTools/Extensions/IComponentModelExtensions.cs
+++ b/src/PowerTools/Extensions/IComponentModelExtensions.cs
@@ -2,9 +2,8 @@
 namespace Microsoft.DbContextPackage.Extensions
 {
     using System;
-    using System.Diagnostics;
-    using Microsoft.DbContextPackage.Utilities;
-    using Microsoft.VisualStudio.ComponentModelHost;
+    using Utilities;
+    using VisualStudio.ComponentModelHost;
 
     internal static class IComponentModelExtensions
     {

--- a/src/PowerTools/Extensions/IEnumerableOfEdmSchemaErrorExtensions.cs
+++ b/src/PowerTools/Extensions/IEnumerableOfEdmSchemaErrorExtensions.cs
@@ -4,7 +4,7 @@ namespace Microsoft.DbContextPackage.Extensions
     using System.Collections.Generic;
     using System.Data.Metadata.Edm;
     using System.Linq;
-    using Microsoft.DbContextPackage.Utilities;
+    using Utilities;
 
     internal static class IEnumerableOfEdmSchemaErrorExtensions
     {

--- a/src/PowerTools/Extensions/ProjectExtensions.cs
+++ b/src/PowerTools/Extensions/ProjectExtensions.cs
@@ -1,5 +1,4 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
-using Microsoft.VisualStudio.OLE.Interop;
 
 namespace Microsoft.DbContextPackage.Extensions
 {
@@ -9,11 +8,10 @@ namespace Microsoft.DbContextPackage.Extensions
     using System.Linq;
     using System.Runtime.InteropServices;
     using EnvDTE;
-    using Microsoft.DbContextPackage.Utilities;
-    using Microsoft.VisualStudio.ComponentModelHost;
-    using Microsoft.VisualStudio.Shell;
-    using Microsoft.VisualStudio.Shell.Interop;
-    using IServiceProvider = IServiceProvider;
+    using Utilities;
+    using VisualStudio.ComponentModelHost;
+    using VisualStudio.Shell;
+    using VisualStudio.Shell.Interop;
 
     internal static class ProjectExtensions
     {

--- a/src/PowerTools/Extensions/ProjectExtensions.cs
+++ b/src/PowerTools/Extensions/ProjectExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DbContextPackage.Extensions
     using VisualStudio.ComponentModelHost;
     using VisualStudio.Shell;
     using VisualStudio.Shell.Interop;
+    using IServiceProvider = VisualStudio.OLE.Interop.IServiceProvider;
 
     internal static class ProjectExtensions
     {

--- a/src/PowerTools/Extensions/ProjectItemsExtensions.cs
+++ b/src/PowerTools/Extensions/ProjectItemsExtensions.cs
@@ -4,7 +4,7 @@ namespace Microsoft.DbContextPackage.Extensions
     using System;
     using System.Linq;
     using EnvDTE;
-    using Microsoft.DbContextPackage.Utilities;
+    using Utilities;
 
     internal static class ProjectItemsExtensions
     {

--- a/src/PowerTools/Extensions/SourceControlExtenstions.cs
+++ b/src/PowerTools/Extensions/SourceControlExtenstions.cs
@@ -2,9 +2,9 @@
 namespace Microsoft.DbContextPackage.Extensions
 {
     using EnvDTE;
-    using Microsoft.DbContextPackage.Utilities;
+    using Utilities;
 
-    internal static class SourceControlExtenstions
+    internal static class SourceControlExtensions
     {
         public static bool CheckOutItemIfNeeded(this SourceControl sourceControl, string itemName)
         {

--- a/src/PowerTools/Extensions/XContainerExtensions.cs
+++ b/src/PowerTools/Extensions/XContainerExtensions.cs
@@ -4,7 +4,7 @@ namespace Microsoft.DbContextPackage.Extensions
     using System.Collections.Generic;
     using System.Linq;
     using System.Xml.Linq;
-    using Microsoft.DbContextPackage.Utilities;
+    using Utilities;
 
     internal static class XContainerExtensions
     {

--- a/src/PowerTools/Handlers/AboutHandler.cs
+++ b/src/PowerTools/Handlers/AboutHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.DbContextPackage.Dialogs;
 
 namespace Microsoft.DbContextPackage.Handlers
 {

--- a/src/PowerTools/Handlers/OptimizeContextHandler.cs
+++ b/src/PowerTools/Handlers/OptimizeContextHandler.cs
@@ -13,13 +13,12 @@ namespace Microsoft.DbContextPackage.Handlers
     using System.Threading.Tasks;
     using System.Windows.Forms;
     using EnvDTE;
-    using Microsoft.DbContextPackage.Extensions;
-    using Microsoft.DbContextPackage.Resources;
-    using Microsoft.DbContextPackage.Utilities;
-    using Microsoft.VisualStudio.Shell.Design;
-    using Microsoft.VisualStudio.Shell.Interop;
+    using Extensions;
+    using Resources;
+    using Utilities;
+    using VisualStudio.Shell.Design;
+    using VisualStudio.Shell.Interop;
     using VSLangProj;
-    using Task = System.Threading.Tasks.Task;
 
     internal class OptimizeContextHandler
     {

--- a/src/PowerTools/Handlers/ViewContextHandler.cs
+++ b/src/PowerTools/Handlers/ViewContextHandler.cs
@@ -4,8 +4,10 @@ namespace Microsoft.DbContextPackage.Handlers
     using System;
     using System.ComponentModel.Design;
     using System.IO;
+    using System.Linq;
     using System.Reflection;
     using System.Xml;
+    using EnvDTE;
     using Resources;
     using Utilities;
 
@@ -30,33 +32,55 @@ namespace Microsoft.DbContextPackage.Handlers
 
             try
             {
-                var filePath = Path.Combine(
-                    Path.GetTempPath(),
-                    contextType.Name
-                        + (menuCommand.CommandID.ID == PkgCmdIDList.cmdidViewEntityDataModel
-                            ? FileExtensions.EntityDataModel
-                            : FileExtensions.Xml));
+                // Use a unique sub-folder (the project GUID) to prevent clashes of same named contexts
+                // from different solutions.
+                var tmpFolder = Path.Combine(Path.GetTempPath(), _package.ProjectGuid.ToString());
+                Directory.CreateDirectory(tmpFolder);
+
+                // Use the context type 'FullName' to distinguish contexts from multiple projects in the same solution
+                var filePath = Path.Combine(tmpFolder, contextType.FullName);
+                filePath = Path.ChangeExtension(filePath,
+                    menuCommand.CommandID.ID == PkgCmdIDList.cmdidViewEntityDataModel
+                        ? FileExtensions.EntityDataModel
+                        : FileExtensions.Xml);
 
                 if (File.Exists(filePath))
                 {
                     File.SetAttributes(filePath, FileAttributes.Normal);
+
+                    // Close the file if already open to eliminate warning dialogs
+                    if (_package.DTE2.ItemOperations.IsFileOpen(filePath))
+                    {
+                        var openDocuments = _package.DTE2.Documents
+                            .OfType<Document>()
+                            .Where(d =>
+                            {
+                                VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
+                                return d.FullName == filePath;
+                            })
+                            .ToList();
+
+                        openDocuments.ForEach(d =>
+                        {
+                            VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
+                            d.Close();
+                        });
+                    }
                 }
 
                 using (var fileStream = File.Create(filePath))
+                using (var xmlWriter = XmlWriter.Create(fileStream, new XmlWriterSettings { Indent = true }))
                 {
-                    using (var xmlWriter = XmlWriter.Create(fileStream, new XmlWriterSettings { Indent = true }))
-                    {
-                        var edmxWriterType = systemContextType.Assembly.GetType("System.Data.Entity.Infrastructure.EdmxWriter");
+                    var edmxWriterType = systemContextType.Assembly.GetType("System.Data.Entity.Infrastructure.EdmxWriter");
 
-                        if (edmxWriterType != null)
-                        {
-                            edmxWriterType.InvokeMember(
-                                "WriteEdmx",
-                                BindingFlags.InvokeMethod | BindingFlags.Static | BindingFlags.Public,
-                                null,
-                                null,
-                                new object[] { context, xmlWriter });
-                        }
+                    if (edmxWriterType != null)
+                    {
+                        edmxWriterType.InvokeMember(
+                            "WriteEdmx",
+                            BindingFlags.InvokeMethod | BindingFlags.Static | BindingFlags.Public,
+                            null,
+                            null,
+                            new object[] { context, xmlWriter });
                     }
                 }
 

--- a/src/PowerTools/Handlers/ViewContextHandler.cs
+++ b/src/PowerTools/Handlers/ViewContextHandler.cs
@@ -6,8 +6,8 @@ namespace Microsoft.DbContextPackage.Handlers
     using System.IO;
     using System.Reflection;
     using System.Xml;
-    using Microsoft.DbContextPackage.Resources;
-    using Microsoft.DbContextPackage.Utilities;
+    using Resources;
+    using Utilities;
 
     internal class ViewContextHandler
     {

--- a/src/PowerTools/Handlers/ViewDdlHandler.cs
+++ b/src/PowerTools/Handlers/ViewDdlHandler.cs
@@ -3,8 +3,8 @@ namespace Microsoft.DbContextPackage.Handlers
 {
     using System;
     using System.IO;
-    using Microsoft.DbContextPackage.Resources;
-    using Microsoft.DbContextPackage.Utilities;
+    using Resources;
+    using Utilities;
 
     internal class ViewDdlHandler
     {

--- a/src/PowerTools/PowerTools.csproj
+++ b/src/PowerTools/PowerTools.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System.Data.Entity" />
     <Reference Include="System.Data.Entity.Design" />
     <Reference Include="System.Design" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />

--- a/src/PowerTools/Properties/AssemblyInfo.cs
+++ b/src/PowerTools/Properties/AssemblyInfo.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Reflection;
 using System.Resources;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/PowerTools/Properties/Resources.cs
+++ b/src/PowerTools/Properties/Resources.cs
@@ -350,7 +350,7 @@ namespace Microsoft.DbContextPackage.Resources
 
         private EntityRes()
         {
-            resources = new ResourceManager("Microsoft.DbContextPackage.Properties.Resources", typeof(Microsoft.DbContextPackage.DbContextPackage).Assembly);
+            resources = new ResourceManager("Microsoft.DbContextPackage.Properties.Resources", typeof(DbContextPackage).Assembly);
         }
 
         private static EntityRes GetLoader()
@@ -381,7 +381,7 @@ namespace Microsoft.DbContextPackage.Resources
             EntityRes sys = GetLoader();
             if (sys == null)
                 return null;
-            string res = sys.resources.GetString(name, EntityRes.Culture);
+            string res = sys.resources.GetString(name, Culture);
 
             if (args != null && args.Length > 0)
             {
@@ -406,7 +406,7 @@ namespace Microsoft.DbContextPackage.Resources
             EntityRes sys = GetLoader();
             if (sys == null)
                 return null;
-            return sys.resources.GetString(name, EntityRes.Culture);
+            return sys.resources.GetString(name, Culture);
         }
 
         public static string GetString(string name, out bool usedFallback)
@@ -421,7 +421,7 @@ namespace Microsoft.DbContextPackage.Resources
             EntityRes sys = GetLoader();
             if (sys == null)
                 return null;
-            return sys.resources.GetObject(name, EntityRes.Culture);
+            return sys.resources.GetObject(name, Culture);
         }
     }
 }

--- a/src/PowerTools/Utilities/CSharpViewGenerator.cs
+++ b/src/PowerTools/Utilities/CSharpViewGenerator.cs
@@ -9,8 +9,6 @@
 // ------------------------------------------------------------------------------
 namespace Microsoft.DbContextPackage.Utilities
 {
-    using System;
-    
     /// <summary>
     /// Class to produce the template output
     /// </summary>

--- a/src/PowerTools/Utilities/EdmxUtility.cs
+++ b/src/PowerTools/Utilities/EdmxUtility.cs
@@ -10,8 +10,8 @@ namespace Microsoft.DbContextPackage.Utilities
     using System.Reflection;
     using System.Xml;
     using System.Xml.Linq;
-    using Microsoft.DbContextPackage.Extensions;
-    using Microsoft.DbContextPackage.Resources;
+    using Extensions;
+    using Resources;
 
     internal class EdmxUtility
     {

--- a/test/PowerTools.Test/Extensions/IComponentModelExtensionsTests.cs
+++ b/test/PowerTools.Test/Extensions/IComponentModelExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 namespace Microsoft.DbContextPackage.Extensions
 {
-    using Microsoft.VisualStudio.ComponentModelHost;
+    using VisualStudio.ComponentModelHost;
     using Moq;
     using Xunit;
 

--- a/test/PowerTools.Test/Properties/AssemblyInfo.cs
+++ b/test/PowerTools.Test/Properties/AssemblyInfo.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/test/PowerTools.Test/Utilities/EdmxUtilityTests.cs
+++ b/test/PowerTools.Test/Utilities/EdmxUtilityTests.cs
@@ -2,13 +2,10 @@
 namespace Microsoft.DbContextPackage.Utilities
 {
     using System;
-    using System.Collections.Generic;
     using System.Data.Mapping;
     using System.IO;
-    using System.Linq;
-    using System.Text;
-    using Microsoft.DbContextPackage.Extensions;
-    using Microsoft.DbContextPackage.Resources;
+    using Extensions;
+    using Resources;
     using Xunit;
 
     public class EdmxUtilityTests


### PR DESCRIPTION
Erik.  

Fixed #43 by creating the .edmx in a sub-folder of the temp folder.  The sub-folder name is now the project guid instead of a random string.

I've changed the name of the .edmx to be the context type 'FullName'.  This makes it easier to see which EDML is which, when there are several open.

If the .edmx is open and the user generates it again I close the open one to eliminate the annoying warning dialogs.

I'm setting the current directory to the project build output folder.  This fixes an issue when there are contexts in multiple projects which have references to other projects.

Most of the files changed are just removing unused 'using' statements.