### PR TITLE
Prepare for MDS 5.2.1

### DIFF
--- a/src/ErikEJ.EntityFramework.SqlServer/ErikEJ.EntityFramework.SqlServer.csproj
+++ b/src/ErikEJ.EntityFramework.SqlServer/ErikEJ.EntityFramework.SqlServer.csproj
@@ -12,11 +12,11 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
 	<PackageId>ErikEJ.EntityFramework.SqlServer</PackageId>
-	<PackageVersion>6.6.10</PackageVersion>
+	<PackageVersion>6.6.11</PackageVersion>
 	<Authors>ErikEJ</Authors>
 	<Description>SQL Server runtime provider for Entity Framework 6.4, using the Microsoft.Data.SqlClient ADO.NET provider.</Description>
 	<PackageProjectUrl>https://github.com/ErikEJ/EntityFramework6PowerTools</PackageProjectUrl>
-	<PackageReleaseNotes>Update to M.D.S. 5.2.0</PackageReleaseNotes>
+	<PackageReleaseNotes>Update to M.D.S. 5.2.1</PackageReleaseNotes>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<MinClientVersion>5.0</MinClientVersion>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/ErikEJ.EntityFramework.SqlServer/MicrosoftSqlProviderServices.cs
+++ b/src/ErikEJ.EntityFramework.SqlServer/MicrosoftSqlProviderServices.cs
@@ -1540,16 +1540,6 @@ namespace System.Data.Entity.SqlServer
             DebugCheck.NotNull(connection);
             DebugCheck.NotNull(factory);
 
-            if (connection is SqlConnection sqlConnection && sqlConnection.AccessTokenCallback != null)
-            {
-                // SqlConnection.Clone doesn't handle this case, so we special-case it here, if later it's fixed in
-                // Microsoft.Data.SqlCLient, we can remove this code piece. See https://github.com/dotnet/SqlClient/issues/2524
-                return new SqlConnection(sqlConnection.ConnectionString)
-                {
-                    AccessTokenCallback = sqlConnection.AccessTokenCallback,
-                };
-            }
-
             var clonableConnection = connection as ICloneable;
             if (clonableConnection != null)
             {

--- a/src/ErikEJ.EntityFramework.SqlServer/readme.md
+++ b/src/ErikEJ.EntityFramework.SqlServer/readme.md
@@ -132,6 +132,26 @@ The following classes have been renamed to avoid conflicts with classes in the e
 
 ## Known issues
 
+**Azure App Service with .NET Framework and connection strings configuration**
+
+If you use Azure App Service with .NET Framework and the [connection strings configuration feature](https://learn.microsoft.com/azure/app-service/configure-common?tabs=portal#configure-connection-strings), you can encounter runtime issues, as the `ProviderName` connection string setting in this scenario is hardcoded to `System.Data.SqlClient`.
+
+Solution is to use a derived MicrosoftSqlDbConfiguration class like this:
+
+```csharp
+public class AppServiceConfiguration : MicrosoftSqlDbConfiguration
+{
+    public AppServiceConfiguration()
+    {
+        SetProviderFactory("System.Data.SqlClient", Microsoft.Data.SqlClient.SqlClientFactory.Instance);
+        SetProviderServices("System.Data.SqlClient", MicrosoftSqlProviderServices.Instance);
+        SetExecutionStrategy("System.Data.SqlClient", () => new MicrosoftSqlAzureExecutionStrategy());
+    }
+}
+```
+
+Then use this derived class in the code-based configuration described above.
+
 **EntityFramework.dll installed in GAC**
 
 If an older version of EntityFramework.dll is installed in the .NET Framework GAC (Global Assembly Cache), you might get this runtime error:
@@ -145,6 +165,11 @@ Solution is to remove the .dll from the GAC, see [this for more info](https://gi
 Please report any issues, questions and suggestions [here](https://github.com/ErikEJ/EntityFramework6PowerTools/issues)
 
 ## Release notes
+
+### 6.6.11
+
+- Uses Microsoft.Data.SqlClient 5.2.1
+- Removed work around for issue https://github.com/dotnet/SqlClient/issues/2524
 
 ### 6.6.10
 


### PR DESCRIPTION
- Removed a block of code in `MicrosoftSqlProviderServices.cs` that was previously necessary due to an issue in `Microsoft.Data.SqlCLient`.
- In `readme.md`, added a new section addressing a known issue with Azure App Service, and updated the release notes for version `6.6.11`.
